### PR TITLE
Concat paths using a "/" instead of File.separator.

### DIFF
--- a/src/main/java/com/sic/plugins/kpp/KPPKeychainsBuildWrapper.java
+++ b/src/main/java/com/sic/plugins/kpp/KPPKeychainsBuildWrapper.java
@@ -176,7 +176,7 @@ public class KPPKeychainsBuildWrapper extends BuildWrapper {
                     String password = keychain.getPassword();
                     String codeSigningIdentity = pair.getCodeSigningIdentity();
                     if (fileName!=null && fileName.length()!=0) {
-                        String keychainPath = String.format("%s%s%s", env.get("WORKSPACE"), File.separator, fileName);
+                        String keychainPath = String.format("%s/%s", env.get("WORKSPACE"), fileName);
                         map.put(pair.getKeychainVariableName(), keychainPath);
                     }
                     if (password!=null && password.length()!=0)

--- a/src/main/java/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper.java
+++ b/src/main/java/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper.java
@@ -143,7 +143,7 @@ public class KPPProvisioningProfilesBuildWrapper extends BuildWrapper {
         }
         
         // remove file seperator char at the end of the path
-        if (toProvisioningProfilesDirectoryPath.endsWith(File.separator)) {
+        if (toProvisioningProfilesDirectoryPath.endsWith("/")) {
             toProvisioningProfilesDirectoryPath = toProvisioningProfilesDirectoryPath.substring(0, toProvisioningProfilesDirectoryPath.length()-1);
         }
         
@@ -155,7 +155,7 @@ public class KPPProvisioningProfilesBuildWrapper extends BuildWrapper {
         
         for (KPPProvisioningProfile pp : provisioningProfiles) {
             FilePath from = new FilePath(hudsonRoot, pp.getProvisioningProfileFilePath());
-            String toPPPath = String.format("%s%s%s", toProvisioningProfilesDirectoryPath, File.separator, KPPProvisioningProfilesProvider.getUUIDFileName(pp.getUuid()));
+            String toPPPath = String.format("%s/%s", toProvisioningProfilesDirectoryPath, KPPProvisioningProfilesProvider.getUUIDFileName(pp.getUuid()));
             FilePath to = new FilePath(channel, toPPPath);
             if (overwriteExistingProfiles || !to.exists()) {
                 from.copyTo(to);

--- a/src/main/java/com/sic/plugins/kpp/model/KPPKeychainCertificatePair.java
+++ b/src/main/java/com/sic/plugins/kpp/model/KPPKeychainCertificatePair.java
@@ -141,7 +141,7 @@ public class KPPKeychainCertificatePair extends AbstractDescribableImpl<KPPKeych
         KPPKeychain k = getKeychainFromString(keychain);
         String filePath = null;
         if (k!=null && k.getFileName()!=null) {
-            filePath = String.format("%s%s%s", KPPKeychainsProvider.getInstance().getUploadDirectoryPath(), File.separator, k.getFileName());
+            filePath = String.format("%s/%s", KPPKeychainsProvider.getInstance().getUploadDirectoryPath(), k.getFileName());
         }
         return filePath;
     }

--- a/src/main/java/com/sic/plugins/kpp/model/KPPProvisioningProfile.java
+++ b/src/main/java/com/sic/plugins/kpp/model/KPPProvisioningProfile.java
@@ -74,7 +74,7 @@ public class KPPProvisioningProfile implements Describable<KPPProvisioningProfil
      */
     public String getProvisioningProfileFilePath() {
         String file = KPPProvisioningProfilesProvider.removeUUIDFromFileName(fileName);
-        return String.format("%s%s%s", KPPProvisioningProfilesProvider.getInstance().getUploadDirectoryPath(), File.separator, file);
+        return String.format("%s/%s", KPPProvisioningProfilesProvider.getInstance().getUploadDirectoryPath(), file);
     }
     
     /**

--- a/src/main/java/com/sic/plugins/kpp/provider/KPPBaseKeychainsProvider.java
+++ b/src/main/java/com/sic/plugins/kpp/provider/KPPBaseKeychainsProvider.java
@@ -124,7 +124,7 @@ public abstract class KPPBaseKeychainsProvider extends KPPBaseProvider implement
             final String ksFolderPath = getUploadDirectoryPath();
             File kFile;
             for (KPPKeychain k : ksCurrent) {
-                kFile = new File(ksFolderPath + File.separator +k.getFileName());
+                kFile = new File(ksFolderPath + "/" + k.getFileName());
                 kFile.delete();
             }
         }

--- a/src/main/java/com/sic/plugins/kpp/provider/KPPBaseProvider.java
+++ b/src/main/java/com/sic/plugins/kpp/provider/KPPBaseProvider.java
@@ -45,7 +45,7 @@ import org.apache.commons.fileupload.FileItem;
 public abstract class KPPBaseProvider {
     
     protected final static Logger LOGGER = Logger.getLogger(KPPBaseProvider.class.getName());
-    private final static String DEFAULT_UPLOAD_DIRECTORY_PATH = Hudson.getInstance().getRootDir() + File.separator + "kpp_upload";
+    private final static String DEFAULT_UPLOAD_DIRECTORY_PATH = Hudson.getInstance().getRootDir() + "/kpp_upload";
     private final String defaultConfigXmlFileName;
     
     /**

--- a/src/main/java/com/sic/plugins/kpp/provider/KPPBaseProvisioningProfilesProvider.java
+++ b/src/main/java/com/sic/plugins/kpp/provider/KPPBaseProvisioningProfilesProvider.java
@@ -141,7 +141,7 @@ public abstract class KPPBaseProvisioningProfilesProvider extends KPPBaseProvide
             final String folderPath = getUploadDirectoryPath();
             File ppFile;
             for (KPPProvisioningProfile pp : ppsCurrent) {
-                ppFile = new File(folderPath + File.separator +pp.getFileName());
+                ppFile = new File(folderPath + "/" + pp.getFileName());
                 ppFile.delete();
             }
         }

--- a/src/main/java/com/sic/plugins/kpp/provider/KPPProvisioningProfilesProvider.java
+++ b/src/main/java/com/sic/plugins/kpp/provider/KPPProvisioningProfilesProvider.java
@@ -57,7 +57,7 @@ public class KPPProvisioningProfilesProvider extends KPPBaseProvisioningProfiles
      * @return file
      */
     public File getProvisioningFile(String fileName) {
-        String path = String.format("%s%s%s", getUploadDirectoryPath(), File.separator, fileName);
+        String path = String.format("%s/%s", getUploadDirectoryPath(), fileName);
         File file = new File(path);
         return file;
     }


### PR DESCRIPTION
I have a strange behavior on my system. For some reason this plugin produces paths with back slashes on my osx jenkins slave. I dont know why, maybe because my Jenkins Master is a Windows machine?
The quickndirty solution I present is to always use a slash as file separator. Should be fine because the plugin can only work on an osx system anyway.