### PR TITLE
Environment variables for team identifier and name of the provisioning profiles.

### DIFF
--- a/src/main/java/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper.java
+++ b/src/main/java/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper.java
@@ -155,7 +155,7 @@ public class KPPProvisioningProfilesBuildWrapper extends BuildWrapper {
         
         for (KPPProvisioningProfile pp : provisioningProfiles) {
             FilePath from = new FilePath(hudsonRoot, pp.getProvisioningProfileFilePath());
-            String toPPPath = String.format("%s%s%s", toProvisioningProfilesDirectoryPath, File.separator, KPPProvisioningProfilesProvider.getUUIDFileName(pp.getUuid()));
+            String toPPPath = String.format("%s%s%s", toProvisioningProfilesDirectoryPath, File.separator, KPPProvisioningProfilesProvider.getUUIDFileName(pp.getProfileUuid()));
             FilePath to = new FilePath(channel, toPPPath);
             if (overwriteExistingProfiles || !to.exists()) {
                 from.copyTo(to);
@@ -208,9 +208,17 @@ public class KPPProvisioningProfilesBuildWrapper extends BuildWrapper {
         private Map<String, String> getEnvMap() {
             Map<String, String> map = new HashMap<String,String>();
             for(KPPProvisioningProfile profile : provisioningProfiles) {
-                String uuid = profile.getUuid();
-                if (uuid != null && uuid.length()!=0) {
-                    map.put(profile.getProvisioningProfileVariableName(), uuid);
+                String profileUuid = profile.getProfileUuid();
+                if (profileUuid != null && profileUuid.length() != 0) {
+                    map.put(profile.getProvisioningProfileVariableName(), profileUuid);
+                }
+                String profileName = profile.getProfileName();
+                if (profileName != null && profileName.length() != 0) {
+                    map.put(profile.getProvisioningProfileSpecifierVariableName(), profileName);
+                }
+                String profileTeamIdentifier = profile.getProfileTeamIdentifier();
+                if (profileTeamIdentifier != null && profileTeamIdentifier.length() != 0) {
+                    map.put(profile.getDevelopmentTeamVariableName(), profileTeamIdentifier);
                 }
             }
             return map;

--- a/src/main/java/com/sic/plugins/kpp/model/KPPProvisioningProfile.java
+++ b/src/main/java/com/sic/plugins/kpp/model/KPPProvisioningProfile.java
@@ -43,11 +43,16 @@ import org.kohsuke.stapler.QueryParameter;
  */
 public class KPPProvisioningProfile implements Describable<KPPProvisioningProfile>, Serializable {
     
+    private final static String DEVELOPMENT_TEAM_BASE_VARIABLE_NAME = "DEVELOPMENT_TEAM";
     private final static String PROVISIONING_PROFILE_BASE_VARIABLE_NAME = "PROVISIONING_PROFILE";
+    private final static String PROVISIONING_PROFILE_SPECIFIER_BASE_VARIABLE_NAME = "PROVISIONING_PROFILE_SPECIFIER";
     
     private final String fileName;
     private final String varPrefix; // variable prefix for build step integration
-    private transient String uuid;
+    
+    private transient String profileUuid;
+    private transient String profileName;
+    private transient String profileTeamIdentifier;
     
     /**
      * Constructor
@@ -86,6 +91,21 @@ public class KPPProvisioningProfile implements Describable<KPPProvisioningProfil
     }
     
     /**
+     * Get the variable name for the development team.
+     * @return variable name.
+     */
+    public String getDevelopmentTeamVariableName() {
+        String name;
+        String prefix = getVarPrefix();
+        if (prefix!=null && !prefix.isEmpty()) {
+            name = String.format("%s_%s", prefix, DEVELOPMENT_TEAM_BASE_VARIABLE_NAME);
+        } else {
+            name = DEVELOPMENT_TEAM_BASE_VARIABLE_NAME;
+        }
+        return name;
+    }
+    
+    /**
      * Get the variable name for the provisioning profile.
      * @return variable name.
      */
@@ -101,6 +121,30 @@ public class KPPProvisioningProfile implements Describable<KPPProvisioningProfil
     }
     
     /**
+     * Get the variable name for the provisioning profile specifier.
+     * @return variable name.
+     */
+    public String getProvisioningProfileSpecifierVariableName() {
+        String name;
+        String prefix = getVarPrefix();
+        if (prefix!=null && !prefix.isEmpty()) {
+            name = String.format("%s_%s", prefix, PROVISIONING_PROFILE_SPECIFIER_BASE_VARIABLE_NAME);
+        } else {
+            name = PROVISIONING_PROFILE_SPECIFIER_BASE_VARIABLE_NAME;
+        }
+        return name;
+    }
+    
+    /**
+     * Get variable names which can be used in other build steps.
+     * @return development team, identifier (uuid) and name variable names
+     */
+    public String getVariableNames() {
+        String variables = String.format("${%s} ${%s} ${%s}", getDevelopmentTeamVariableName(), getProvisioningProfileVariableName(), getProvisioningProfileSpecifierVariableName());
+        return variables;
+    }
+    
+    /**
      * Get the variable name included in ${}.
      * @return variable name
      */
@@ -112,11 +156,33 @@ public class KPPProvisioningProfile implements Describable<KPPProvisioningProfil
      * Get the uuid of the provisioning profile.
      * @return uuid
      */
-    public String getUuid() {
-        if (uuid==null || uuid.isEmpty()) {
-            uuid = KPPProvisioningProfilesProvider.parseUUIDFromProvisioningProfileFile(fileName);
+    public String getProfileUuid() {
+        if (profileUuid==null || profileUuid.isEmpty()) {
+            profileUuid = KPPProvisioningProfilesProvider.parseUUIDFromProvisioningProfileFile(fileName);
         }
-        return uuid;
+        return profileUuid;
+    }
+    
+    /**
+     * Get the name of the provisioning profile.
+     * @return name
+     */
+    public String getProfileName() {
+        if (profileName==null || profileName.isEmpty()) {
+            profileName = KPPProvisioningProfilesProvider.parseNameFromProvisioningProfileFile(fileName);
+        }
+        return profileName;
+    }
+    
+    /**
+     * Get the team identifier of the provisioning profile.
+     * @return team identifier
+     */
+    public String getProfileTeamIdentifier() {
+        if (profileTeamIdentifier==null || profileTeamIdentifier.isEmpty()) {
+            profileTeamIdentifier = KPPProvisioningProfilesProvider.parseTeamIdentifierFromProvisioningProfileFile(fileName);
+        }
+        return profileTeamIdentifier;
     }
     
     /**
@@ -124,7 +190,7 @@ public class KPPProvisioningProfile implements Describable<KPPProvisioningProfil
      * @return filename and uuid
      */
     public String getFileNameUuidDescription() {
-        return String.format("%s (%s)", getFileName(), getUuid());
+        return String.format("%s (%s)", getFileName(), getProfileUuid());
     }
     
     @Override

--- a/src/main/java/com/sic/plugins/kpp/provider/KPPProvisioningProfilesProvider.java
+++ b/src/main/java/com/sic/plugins/kpp/provider/KPPProvisioningProfilesProvider.java
@@ -105,4 +105,92 @@ public class KPPProvisioningProfilesProvider extends KPPBaseProvisioningProfiles
         }
         return uuid;
     }
+    
+    /**
+     * Parse the Name from the content of the provisioning profile file.
+     * @param fileName name of the provisioning profile file
+     * @return Name
+     */
+    public static String parseNameFromProvisioningProfileFile(String fileName) {
+        String name = "Name not found";
+        BufferedReader br = null;
+        try {
+            String fileNameWithoutUUID = KPPBaseProvisioningProfilesProvider.removeUUIDFromFileName(fileName);
+            File file = KPPProvisioningProfilesProvider.getInstance().getProvisioningFile(fileNameWithoutUUID);
+            FileReader reader = new FileReader(file);
+            br = new BufferedReader(reader);
+            String line;
+            boolean foundName = false;
+            while (br!=null && (line = br.readLine()) != null) {
+                if (line.contains("<key>Name</key>")) {
+                    foundName = true; // next line is value
+                } else if (foundName) {
+                    final String openTag = "<string>";
+                    final String closeTag = "</string>";
+                    // parse value for Name key
+                    int indexOfOpenTag = line.indexOf(openTag);
+                    int indexOfCloseTag = line.indexOf(closeTag);
+                    if (indexOfOpenTag != -1 && indexOfCloseTag != -1 && indexOfOpenTag < indexOfCloseTag) {
+                        name = line.substring(indexOfOpenTag+openTag.length(), indexOfCloseTag);
+                    }
+                    break;
+                }
+            }
+        } catch (FileNotFoundException ex) {
+            LOGGER.log(Level.SEVERE, null, ex);
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, null, ex);
+        } finally {
+            try {
+                br.close();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, null, ex);
+            }
+        }
+        return name;
+    }
+    
+    /**
+     * Parse the TeamIdentifier from the content of the provisioning profile file.
+     * @param fileName name of the provisioning profile file
+     * @return TeamIdentifier
+     */
+    public static String parseTeamIdentifierFromProvisioningProfileFile(String fileName) {
+        String teamIdentifier = "TeamIdentifier not found";
+        BufferedReader br = null;
+        try {
+            String fileNameWithoutUUID = KPPBaseProvisioningProfilesProvider.removeUUIDFromFileName(fileName);
+            File file = KPPProvisioningProfilesProvider.getInstance().getProvisioningFile(fileNameWithoutUUID);
+            FileReader reader = new FileReader(file);
+            br = new BufferedReader(reader);
+            String line;
+            boolean foundTeamIdentifier = false;
+            while (br!=null && (line = br.readLine()) != null) {
+                if (line.contains("<key>com.apple.developer.team-identifier</key>")) {
+                    foundTeamIdentifier = true; // next line is value
+                } else if (foundTeamIdentifier) {
+                    final String openTag = "<string>";
+                    final String closeTag = "</string>";
+                    // parse value for Name key
+                    int indexOfOpenTag = line.indexOf(openTag);
+                    int indexOfCloseTag = line.indexOf(closeTag);
+                    if (indexOfOpenTag != -1 && indexOfCloseTag != -1 && indexOfOpenTag < indexOfCloseTag) {
+                        teamIdentifier = line.substring(indexOfOpenTag+openTag.length(), indexOfCloseTag);
+                    }
+                    break;
+                }
+            }
+        } catch (FileNotFoundException ex) {
+            LOGGER.log(Level.SEVERE, null, ex);
+        } catch (IOException ex) {
+            LOGGER.log(Level.SEVERE, null, ex);
+        } finally {
+            try {
+                br.close();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, null, ex);
+            }
+        }
+        return teamIdentifier;
+    }
 }

--- a/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
                 <f:entry title="${%prefix}" field="varPrefix" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-varPrefix.jelly">
                     <f:textbox />
                 </f:entry>
-                <f:entry title="${%variable}" field="variableName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-variableName.jelly">
+                <f:entry title="${%variables}" field="variableNames" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-variableNames.jelly">
                     <f:readOnlyTextbox/>
                 </f:entry>
                 <f:entry title="">

--- a/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.properties
+++ b/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.properties
@@ -25,6 +25,6 @@ delete = Delete copied provisioning profiles after build
 add_btn = Add Provisioning Profile
 profile = Provisioning Profile
 prefix = Variable Prefix
-variable = Variable
+variables = Variables
 delete_btn = Delete
 

--- a/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.jelly
@@ -29,8 +29,14 @@ THE SOFTWARE.
         <f:entry title="${%filename}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-fileName.jelly">
             <f:readOnlyTextbox value="${it.fileName}"/>
         </f:entry>
+        <f:entry title="${%teamIdentifier}" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-teamIdentifier.jelly">
+            <f:readOnlyTextbox value="${it.profileTeamIdentifier}"/>
+        </f:entry>
         <f:entry title="${%uuid}" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-uuid.jelly">
-            <f:readOnlyTextbox value="${it.uuid}"/>
+            <f:readOnlyTextbox value="${it.profileUuid}"/>
+        </f:entry>
+        <f:entry title="${%name}" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-name.jelly">
+            <f:readOnlyTextbox value="${it.profileName}"/>
         </f:entry>
         <f:entry title="">
             <div align="right">

--- a/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.properties
+++ b/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.properties
@@ -21,6 +21,8 @@
 # THE SOFTWARE.
 
 filename = Filename
+teamIdentifier = Team Identifier
 uuid = UUID
+name = Name
 delete_btn = Delete Provisioning Profile
 

--- a/src/main/webapp/model/KPPProvisioningProfile/help-name.jelly
+++ b/src/main/webapp/model/KPPProvisioningProfile/help-name.jelly
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2013 Michael Bär SIC! Software GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
+    The automatically detected name of the provisioning profile.
+</j:jelly>

--- a/src/main/webapp/model/KPPProvisioningProfile/help-teamIdentifier.jelly
+++ b/src/main/webapp/model/KPPProvisioningProfile/help-teamIdentifier.jelly
@@ -25,9 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
-    Variables added to the build environment. They can be used in other build steps.
-    <dl>
-        <dt>${PROVISIONING_PROFILE}</dt>
-        <dd>Contains the uuid of the provisioning profile.</dd>
-    </dl>
+    The automatically detected team identifier of the provisioning profile.
 </j:jelly>

--- a/src/main/webapp/model/KPPProvisioningProfile/help-variableNames.jelly
+++ b/src/main/webapp/model/KPPProvisioningProfile/help-variableNames.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2013 Michael Bär SIC! Software GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
+    Variables added to the build environment. They can be used in other build steps.
+    <dl>
+        <dt>${DEVELOPMENT_TEAM}</dt>
+        <dd>Contains the team identifier of the provisioning profile.</dd>
+        <dt>${PROVISIONING_PROFILE}</dt>
+        <dd>Contains the uuid of the provisioning profile.</dd>
+        <dt>${PROVISIONING_PROFILE_SPECIFIER}</dt>
+        <dd>Contains the name of the provisioning profile.</dd>
+    </dl>
+</j:jelly>


### PR DESCRIPTION
Xcode 8 requires an id of the development team and name (specifier) of the provisioning profile for new app signing procedure (manual mode). This PR adds an DEVELOPMENT_TEAM and PROVISIONING_PROFILE_SPECIFIER environment variables calculated from contents of .mobileprovisioning file. 