### PR TITLE
Remove all tables in forms for Jenkins 2.277.1+ compatibility

### DIFF
--- a/src/main/resources/com/sic/plugins/kpp/KPPKeychainsBuildWrapper/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/KPPKeychainsBuildWrapper/config.jelly
@@ -33,25 +33,23 @@ THE SOFTWARE.
     </f:entry>
     <f:block>
         <f:repeatable var="keychainCertificatePair" field="keychainCertificatePairs" minimum="1" add="${%add_btn}">
-            <table width="100%">
-                <f:entry title="${%keychain}" field="keychain" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-keychain.jelly">
-                    <f:select />
-                </f:entry>
-                <f:entry title="${%identity}" field="codeSigningIdentity" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-codeSigningIdentity.jelly">
-                    <f:select />
-                </f:entry>
-                <f:entry title="${%prefix}" field="varPrefix" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-varPrefix.jelly">
-                    <f:textbox />
-                </f:entry>
-                <f:entry title="${%variables}" field="variableNames" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-variableNames.jelly">
-                    <f:readOnlyTextbox/>
-                </f:entry>
-                <f:entry title="">
-                    <div align="right">
-                        <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
-                    </div>
-                </f:entry>
-            </table>
+            <f:entry title="${%keychain}" field="keychain" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-keychain.jelly">
+                <f:select />
+            </f:entry>
+            <f:entry title="${%identity}" field="codeSigningIdentity" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-codeSigningIdentity.jelly">
+                <f:select />
+            </f:entry>
+            <f:entry title="${%prefix}" field="varPrefix" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-varPrefix.jelly">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="${%variables}" field="variableNames" help="/plugin/kpp-management-plugin/model/KPPKeychainCertificatePair/help-variableNames.jelly">
+                <f:readOnlyTextbox/>
+            </f:entry>
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
+                </div>
+            </f:entry>
         </f:repeatable>
     </f:block>
 </j:jelly>

--- a/src/main/resources/com/sic/plugins/kpp/KPPManagementLink/index.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/KPPManagementLink/index.jelly
@@ -37,34 +37,28 @@ THE SOFTWARE.
             <j:if test="${!empty(error)}">
                 <div style="font-size: 1.2em; background-color: red; padding: 5px; color: white;">${%error} ${error}</div>
             </j:if>
-            <table width="100%">
-                <f:section title="${%upload_title}"></f:section>
-                <f:block>
-                    <f:form method="post" action="uploadFile">
-                        <f:block>
-                            <input type="file" name="file"/>
-                        </f:block>
-                        <f:block>
-                            <f:submit value="${%upload_btn}"/>
-                        </f:block>
-                    </f:form>
-                </f:block>
-            </table>
+            <f:section title="${%upload_title}"></f:section>
+            <f:block>
+                <f:form method="post" action="uploadFile">
+                    <f:block>
+                        <input type="file" name="file"/>
+                    </f:block>
+                    <f:block>
+                        <f:submit value="${%upload_btn}"/>
+                    </f:block>
+                </f:form>
+            </f:block>
             <f:form method="post" action="save">
-                <table width="100%">
-                    <f:section title="${%keychain_title}"></f:section>
-                </table>
+                <f:section title="${%keychain_title}"></f:section>
                 <f:repeatable var="keychain" items="${it.keychains}" minimum="0" noAddButton="true" header="">
                     <j:if test="${!empty(keychain)}">
                         <st:include it="${keychain}" page="config.jelly"/>
                     </j:if>
                 </f:repeatable>
-                <table width="100%">
-                    <f:section title="${%profiles_title}"></f:section>
-                    <f:entry title="${%profiles_path}" field="provisioningProfilesPath" help="/plugin/kpp-management-plugin/KPPManagementLink/help-provisioningProfilesPath.jelly">
-                        <f:textbox value="${it.provisioningProfilesPath}"/>
-                    </f:entry>
-                </table>
+                <f:section title="${%profiles_title}"></f:section>
+                <f:entry title="${%profiles_path}" field="provisioningProfilesPath" help="/plugin/kpp-management-plugin/KPPManagementLink/help-provisioningProfilesPath.jelly">
+                    <f:textbox value="${it.provisioningProfilesPath}"/>
+                </f:entry>
                 <f:repeatable var="profile" items="${it.provisioningProfiles}" minimum="0" noAddButton="true" header="">
                     <j:if test="${!empty(profile)}">
                         <st:include it="${profile}" page="config.jelly"/>

--- a/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/KPPProvisioningProfilesBuildWrapper/config.jelly
@@ -33,22 +33,20 @@ THE SOFTWARE.
     </f:entry>
     <f:block>
         <f:repeatable var="provisioningProfile" field="provisioningProfiles" minimum="1" add="${%add_btn}">
-            <table width="100%">
-                <f:entry title="${%profile}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-build-fileName.jelly">
-                    <f:select />
-                </f:entry>
-                <f:entry title="${%prefix}" field="varPrefix" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-varPrefix.jelly">
-                    <f:textbox />
-                </f:entry>
-                <f:entry title="${%variable}" field="variableName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-variableName.jelly">
-                    <f:readOnlyTextbox/>
-                </f:entry>
-                <f:entry title="">
-                    <div align="right">
-                        <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
-                    </div>
-                </f:entry>
-            </table>
+            <f:entry title="${%profile}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-build-fileName.jelly">
+                <f:select />
+            </f:entry>
+            <f:entry title="${%prefix}" field="varPrefix" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-varPrefix.jelly">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="${%variable}" field="variableName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-variableName.jelly">
+                <f:readOnlyTextbox/>
+            </f:entry>
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
+                </div>
+            </f:entry>
         </f:repeatable>
     </f:block>
     

--- a/src/main/resources/com/sic/plugins/kpp/model/KPPKeychain/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/model/KPPKeychain/config.jelly
@@ -25,35 +25,31 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <table width="100%">
-        <f:entry title="${%filename}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-filename.jelly">
-            <f:readOnlyTextbox value="${it.fileName}"/>
-        </f:entry>
-        <f:entry title="${%password}" field="password" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-password.jelly">
-            <f:password value="${it.password}"></f:password>
-        </f:entry>
-        <f:entry title="${%description}" field="description" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-description.jelly">
-            <f:textbox value="${it.description}"></f:textbox>
-        </f:entry>
-        <f:entry title="${%identities}">
-            <f:repeatable var="certificates" items="${it.certificates}" minimum="1" add="${%add_btn}" header="">
-                <table width="100%">
-                <f:entry title="${%identity}" field="codeSigningIdentityName" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-codeSigningIdentityName.jelly">
-                    <f:textbox value="${certificates.codeSigningIdentityName}"/>
-                </f:entry>
-                <f:block>
-                    <div align="right">
-                        <f:repeatableDeleteButton value="${%delete_identity_btn}"></f:repeatableDeleteButton>
-                    </div>
-                </f:block>
-                </table>
-            </f:repeatable>
-        </f:entry>
-            
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton value="${%delete_keychain_btn}"></f:repeatableDeleteButton>
-            </div>
-        </f:entry>
-    </table>
+    <f:entry title="${%filename}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-filename.jelly">
+        <f:readOnlyTextbox value="${it.fileName}"/>
+    </f:entry>
+    <f:entry title="${%password}" field="password" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-password.jelly">
+        <f:password value="${it.password}"></f:password>
+    </f:entry>
+    <f:entry title="${%description}" field="description" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-description.jelly">
+        <f:textbox value="${it.description}"></f:textbox>
+    </f:entry>
+    <f:entry title="${%identities}">
+        <f:repeatable var="certificates" items="${it.certificates}" minimum="1" add="${%add_btn}" header="">
+            <f:entry title="${%identity}" field="codeSigningIdentityName" help="/plugin/kpp-management-plugin/model/KPPKeychain/help-codeSigningIdentityName.jelly">
+                <f:textbox value="${certificates.codeSigningIdentityName}"/>
+            </f:entry>
+            <f:block>
+                <div align="right">
+                    <f:repeatableDeleteButton value="${%delete_identity_btn}"></f:repeatableDeleteButton>
+                </div>
+            </f:block>
+        </f:repeatable>
+    </f:entry>
+        
+    <f:entry title="">
+        <div align="right">
+            <f:repeatableDeleteButton value="${%delete_keychain_btn}"></f:repeatableDeleteButton>
+        </div>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.jelly
+++ b/src/main/resources/com/sic/plugins/kpp/model/KPPProvisioningProfile/config.jelly
@@ -25,17 +25,15 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <table width="100%">
-        <f:entry title="${%filename}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-fileName.jelly">
-            <f:readOnlyTextbox value="${it.fileName}"/>
-        </f:entry>
-        <f:entry title="${%uuid}" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-uuid.jelly">
-            <f:readOnlyTextbox value="${it.uuid}"/>
-        </f:entry>
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
-            </div>
-        </f:entry>
-    </table>
+    <f:entry title="${%filename}" field="fileName" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-fileName.jelly">
+        <f:readOnlyTextbox value="${it.fileName}"/>
+    </f:entry>
+    <f:entry title="${%uuid}" help="/plugin/kpp-management-plugin/model/KPPProvisioningProfile/help-uuid.jelly">
+        <f:readOnlyTextbox value="${it.uuid}"/>
+    </f:entry>
+    <f:entry title="">
+        <div align="right">
+            <f:repeatableDeleteButton value="${%delete_btn}"></f:repeatableDeleteButton>
+        </div>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This resolves this issue: https://issues.jenkins.io/browse/JENKINS-64780

See https://www.jenkins.io/doc/developer/views/table-to-div-migration/

Since Jenkins 2.277.1, forms generated by KPP cannot be saved because of generic error: `TypeError: e.getAttribute is not a function[...]`.
This stems from an issue somewhere in the templating code that doesn't recognize the `<table>` tags properly and as a result, the HTML generated is not correct: parts of jelly tags that should be inside `<form>` tags are now after it, which causes both rendering issues and the aformentioned error.

### Testing done

I've built and tested the changes on a local server using a recent Jenkins version. 
I've confirmed the rendering issues are no longer there and the forms can now be saved properly.
